### PR TITLE
Support 'embeds' parameter to discord API

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ e.g.: `Action called: {{ GITHUB_ACTION }} as {{ EVENT_PAYLOAD.pull_request.id }}
   * ***IMPORTANT !!* You MUST NOT append `/github` at the end of the webhook.**
 * **`DISCORD_USERNAME`** (*optional*): overrides the bot nickname.
 * **`DISCORD_AVATAR`** (*optional*): overrides the avatar URL.
-* **`DISCORD_EMBEDS`** (*optional*): This should be a valid JSON string of an array of Discord `embed` objects. See the [documentation on Discord WebHook Embeds](https://birdie0.github.io/discord-webhooks-guide/structure/embeds.html) for more information.
+* **`DISCORD_EMBEDS`** (*optional*): This should be a valid JSON string of an array of Discord `embed` objects. See the [documentation on Discord WebHook Embeds](https://birdie0.github.io/discord-webhooks-guide/structure/embeds.html) for more information. You can use set it to `${{ toJson(my_value) }}` using [`toJson()`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#tojson) if your input is an object value.
 * That's all.
 
 ## Alternatives

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ e.g.: `Action called: {{ GITHUB_ACTION }} as {{ EVENT_PAYLOAD.pull_request.id }}
   * ***IMPORTANT !!* You MUST NOT append `/github` at the end of the webhook.**
 * **`DISCORD_USERNAME`** (*optional*): overrides the bot nickname.
 * **`DISCORD_AVATAR`** (*optional*): overrides the avatar URL.
+* **`DISCORD_EMBEDS`** (*optional*): This should be a valid JSON string of an array of Discord `embed` objects. See the [documentation on Discord WebHook Embeds](https://birdie0.github.io/discord-webhooks-guide/structure/embeds.html) for more information.
 * That's all.
 
 ## Alternatives

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -53,7 +53,7 @@ if (argv._.length === 0 && !process.env.DISCORD_EMBEDS) {
   url = process.env.DISCORD_WEBHOOK;
   payload = JSON.stringify({
     content: message,
-    ...process.env.DISCORD_EMBEDS && { embeds: embedsObject},
+    ...process.env.DISCORD_EMBEDS && { embeds: embedsObject },
     ...process.env.DISCORD_USERNAME && { username: process.env.DISCORD_USERNAME },
     ...process.env.DISCORD_AVATAR && { avatar_url: process.env.DISCORD_AVATAR },
   });

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -41,14 +41,15 @@ if (argv._.length === 0 && !process.env.DISCORD_EMBEDS) {
   const message = _.template(args)({ ...process.env, EVENT_PAYLOAD: JSON.parse(eventContent) });
 
   let embedsObject;
-  if(process.env.DISCORD_EMBEDS){
+  if (process.env.DISCORD_EMBEDS) {
      try {
         embedsObject = JSON.parse(process.env.DISCORD_EMBEDS);
      } catch (parseErr) {
-       console.error('Error parsing DISCORD_EMBEDS:' + parseErr);
+       console.error('Error parsing DISCORD_EMBEDS :' + parseErr);
        process.exit(1);
      }
   }
+
   url = process.env.DISCORD_WEBHOOK;
   payload = JSON.stringify({
     content: message,

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -32,7 +32,12 @@ let payload;
 if (argv._.length === 0) {
   // If argument NOT provided, let Discord show the event informations.
   url = `${process.env.DISCORD_WEBHOOK}/github`;
-  payload = JSON.stringify(JSON.parse(eventContent));
+  let eventContentObj = JSON.parse(eventContent);
+  payload = JSON.stringify({
+    ...eventContentObj;
+    ...process.env.DISCORD_USERNAME && { username: process.env.DISCORD_USERNAME },
+    ...process.env.DISCORD_AVATAR && { avatar_url: process.env.DISCORD_AVATAR },    
+  });
 } else {
   // Otherwise, if the argument is provided, let Discord override the message.
   const args = argv._.join(' ');


### PR DESCRIPTION
Hi,

Support [embeds](https://birdie0.github.io/discord-webhooks-guide/structure/embeds.html) for discord notifications. Probably best for people to try to generate them in a previous step and set them there with ::set-env or ::set-output

Related #41 
Let me know any changes you would like.

