### PR TITLE
Fixes typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ As this Action is containerized with Docker, [it can only run on Linux environme
 
 **NOTICE :** for stability purposes, it is recommended to use the action with an explicit commit SHA-1 :
 
-* Version : `uses: "Ilshidur/actions-discord@0.2.0"` (&rarr; link to the releases list : https://github.com/Ilshidur/action-discord/releases)
-* Commit SHA-1 : `uses: "Ilshidur/actions-discord@fbd91a9"` (&rarr; link to the commits list : https://github.com/Ilshidur/action-discord/commits/master)
+* Version : `uses: "Ilshidur/action-discord@0.2.0"` (&rarr; link to the releases list : https://github.com/Ilshidur/action-discord/releases)
+* Commit SHA-1 : `uses: "Ilshidur/action-discord@fbd91a9"` (&rarr; link to the commits list : https://github.com/Ilshidur/action-discord/commits/master)
 
 ### Arguments
 


### PR DESCRIPTION
The action/repo is actually "Ilshidur/action-discord", was twice actions instead.

Also credit to @Conor12345 while working together on AlternativeFFFF/Alt-F4#6 for spotting it.