### PR TITLE
Support multiline content message

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -15,5 +15,6 @@ GITHUB_EVENT_PATH=./event-example.json
 DISCORD_WEBHOOK=
 DISCORD_USERNAME=OSS 117
 DISCORD_AVATAR=https://resize.programme-television.ladmedia.fr/r/670,670/img/var/premiere/storage/images/tele-7-jours/news-tv/oss-117-le-caire-nid-d-espions-c8-le-show-de-jean-dujardin-4484285/90175763-1-fre-FR/OSS-117-Le-Caire-nid-d-espions-C8-Le-show-de-Jean-Dujardin.jpg
+DISCORD_MULTILINE=0
 
 NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ e.g.: `Action called: {{ GITHUB_ACTION }} as {{ EVENT_PAYLOAD.pull_request.id }}
 * **`DISCORD_USERNAME`** (*optional*): overrides the bot nickname.
 * **`DISCORD_AVATAR`** (*optional*): overrides the avatar URL.
 * **`DISCORD_EMBEDS`** (*optional*): This should be a valid JSON string of an array of Discord `embed` objects. See the [documentation on Discord WebHook Embeds](https://birdie0.github.io/discord-webhooks-guide/structure/embeds.html) for more information. You can use set it to `${{ toJson(my_value) }}` using [`toJson()`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#tojson) if your input is an object value.
+* **`DISCORD_MULTILINE`** (*optional*): permit us to write a multiline message. The `\n` will be interpreted like a new line.
 * That's all.
 
 ## Alternatives

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -38,7 +38,11 @@ if (argv._.length === 0 && !process.env.DISCORD_EMBEDS) {
 } else {
   // Otherwise, if the argument or embeds are provided, let Discord override the message.
   const args = argv._.join(' ');
-  const message = _.template(args)({ ...process.env, EVENT_PAYLOAD: JSON.parse(eventContent) });
+  let message = _.template(args)({ ...process.env, EVENT_PAYLOAD: JSON.parse(eventContent) });
+
+  if (process.env.DISCORD_MULTILINE == true) {
+    message = message.replace(/\\n/g, '\n');
+  }
 
   let embedsObject;
   if (process.env.DISCORD_EMBEDS) {


### PR DESCRIPTION
Hello !

Thanks for your GA, it is very useful in our workflow 👌

### Problem

I found that it is not easy to write a multiline message with this plugin.

### Exemple

```yaml
- name: Discord notification
  env:
    DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
  uses: Ilshidur/action-discord@master
  with:
    args: 'Hello\nHow are you?'
```

Result with:
![image](https://user-images.githubusercontent.com/24540801/95519866-5342e680-09c6-11eb-8a3d-3f380d1d3719.png)

### Solution

I added a new environment variable called `DISCORD_MULTILINE` (boolean).
When `DISCORD_MULTILINE` is set to true, we make sure that the `\n` will be replace with new lines 🎉

```yaml
- name: Discord notification
  env:
    DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
    DISCORD_MULTILINE: true
  uses: Ilshidur/action-discord@master
  with:
    args: 'Release notes:\n- 🚀 New features\n- ✨ Cool stuff'
```

![image](https://user-images.githubusercontent.com/24540801/95520492-b2edc180-09c7-11eb-9e66-76724401077d.png)

What do you think?