### PR TITLE
Add a wait parameter prefix to the webhook url

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -42,12 +42,12 @@ if (argv._.length === 0 && !process.env.DISCORD_EMBEDS) {
 
   let embedsObject;
   if (process.env.DISCORD_EMBEDS) {
-     try {
-        embedsObject = JSON.parse(process.env.DISCORD_EMBEDS);
-     } catch (parseErr) {
-       console.error('Error parsing DISCORD_EMBEDS :' + parseErr);
-       process.exit(1);
-     }
+    try {
+      embedsObject = JSON.parse(process.env.DISCORD_EMBEDS);
+    } catch (parseErr) {
+      console.error('Error parsing DISCORD_EMBEDS :' + parseErr);
+      process.exit(1);
+    }
   }
 
   url = process.env.DISCORD_WEBHOOK;
@@ -61,10 +61,12 @@ if (argv._.length === 0 && !process.env.DISCORD_EMBEDS) {
 
 // curl -X POST -H "Content-Type: application/json" --data "$(cat $GITHUB_EVENT_PATH)" $DISCORD_WEBHOOK/github
 
+let waitParamPrefix = url.includes('?') ? '&' : '?';
+
 (async () => {
   console.log('Sending message ...');
   await axios.post(
-    `${url}?wait=true`,
+    `${url}${waitParamPrefix}wait=true`,
     payload,
     {
       headers: {


### PR DESCRIPTION
## Why
This PR is to allow URLs that contain query strings. An example being a webhook to a thread.

## What changed
This PR checks the existence of a of a query string by keying off the `?` character. If this exists, the `wait=true` parameter is prefixed with an `&` otherwise it is prefixed with the default `?`.

Additionally this includes a few formatting fixes for inconsistent indentation.

## Linked issues
relates to #115 