### PR TITLE
feat: add support for DISCORD_MENTIONS in payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ e.g.: `Action called: {{ GITHUB_ACTION }} as {{ EVENT_PAYLOAD.pull_request.id }}
   * ***IMPORTANT !!* You MUST NOT append `/github` at the end of the webhook.**
 * **`DISCORD_USERNAME`** (*optional*): overrides the bot nickname.
 * **`DISCORD_AVATAR`** (*optional*): overrides the avatar URL.
-* **`DISCORD_EMBEDS`** (*optional*): This should be a valid JSON string of an array of Discord `embed` objects. See the [documentation on Discord WebHook Embeds](https://birdie0.github.io/discord-webhooks-guide/structure/embeds.html) for more information. You can use set it to `${{ toJson(my_value) }}` using [`toJson()`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#tojson) if your input is an object value.
+* **`DISCORD_MENTIONS`** (*optional*): A valid JSON string of a Discord `allowed_mentions` object. See the [Discord Allowed Mentions documentation](https://birdie0.github.io/discord-webhooks-guide/structure/allowed_mentions.html).
+* **`DISCORD_EMBEDS`** (*optional*): A valid JSON string of an array of Discord `embed` objects. See the [Discord WebHook Embeds documentation](https://birdie0.github.io/discord-webhooks-guide/structure/embeds.html).
+
+> **Note:** For `DISCORD_MENTIONS` and `DISCORD_EMBEDS`, you can use `${{ toJson(my_value) }}` with the [`toJson()`](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#tojson) function if your input is an object value.
 * That's all.
 
 ## Alternatives

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -41,6 +41,7 @@ if (argv._.length === 0 && !process.env.DISCORD_EMBEDS) {
   const message = _.template(args)({ ...process.env, EVENT_PAYLOAD: JSON.parse(eventContent) });
 
   let embedsObject;
+  let mentionsObject;
   if (process.env.DISCORD_EMBEDS) {
      try {
         embedsObject = JSON.parse(process.env.DISCORD_EMBEDS);
@@ -49,13 +50,26 @@ if (argv._.length === 0 && !process.env.DISCORD_EMBEDS) {
        process.exit(1);
      }
   }
+  if (process.env.DISCORD_MENTIONS) {
+     try {
+        mentionsObject = JSON.parse(process.env.DISCORD_MENTIONS);
+     } catch (parseErr) {
+       console.error('Error parsing DISCORD_MENTIONS :' + parseErr);
+       process.exit(1);
+     }
+  }
 
   url = process.env.DISCORD_WEBHOOK;
   payload = JSON.stringify({
     content: message,
-    ...process.env.DISCORD_EMBEDS && { embeds: embedsObject },
-    ...process.env.DISCORD_USERNAME && { username: process.env.DISCORD_USERNAME },
-    ...process.env.DISCORD_AVATAR && { avatar_url: process.env.DISCORD_AVATAR },
+    ...(process.env.DISCORD_EMBEDS && { embeds: embedsObject }),
+    ...(process.env.DISCORD_MENTIONS && { allowed_mentions: mentionsObject }),
+    ...(process.env.DISCORD_USERNAME && {
+      username: process.env.DISCORD_USERNAME,
+    }),
+    ...(process.env.DISCORD_AVATAR && {
+      avatar_url: process.env.DISCORD_AVATAR,
+    }),
   });
 }
 


### PR DESCRIPTION
## Add support for Discord mentions configuration

### Summary
This PR adds support for the `DISCORD_MENTIONS` environment variable, allowing users to configure Discord's `allowed_mentions` parameter when sending notifications.

### Changes
- Added parsing and handling of the `DISCORD_MENTIONS` environment variable in `entrypoint.js`
- Implemented JSON parsing with error handling for the mentions configuration
- Integrated the parsed mentions object into the Discord webhook payload using the `allowed_mentions` field

### Usage
Users can now set the `DISCORD_MENTIONS` environment variable with a valid JSON string to control mention behavior:

```yaml
env:
  DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
  DISCORD_MENTIONS: '{"parse": ["users", "roles"], "users": ["123456789"]}'